### PR TITLE
docs: add documentation for autodiff, rope, and SAT solver

### DIFF
--- a/docs/autodiff.html
+++ b/docs/autodiff.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Automatic Differentiation — OCaml Sample Code</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav><a href="index.html">← Home</a></nav>
+  <main>
+    <h1>🧮 Automatic Differentiation</h1>
+    <p class="subtitle">Exact derivatives via dual numbers and computation graphs</p>
+
+    <section>
+      <h2>Overview</h2>
+      <p>A complete <strong>automatic differentiation</strong> library supporting both
+      forward mode (dual numbers) and reverse mode (computation graphs). Unlike
+      symbolic differentiation (which manipulates expressions) or numerical
+      differentiation (which approximates with finite differences), AD computes
+      <strong>exact derivatives</strong> at machine precision by applying the chain rule
+      to elementary operations.</p>
+      <p>This is the core technique behind modern deep learning frameworks like
+      PyTorch and TensorFlow, implemented from scratch in ~1000 lines of OCaml.</p>
+    </section>
+
+    <section>
+      <h2>Concepts Demonstrated</h2>
+      <ul>
+        <li><strong>Dual numbers</strong> — forward-mode AD via (value, derivative) pairs</li>
+        <li><strong>Computation graphs</strong> — reverse-mode AD with backpropagation</li>
+        <li><strong>Operator overloading</strong> — seamless derivative tracking through arithmetic</li>
+        <li><strong>Chain rule</strong> — composing derivatives of elementary operations</li>
+        <li><strong>Gradient computation</strong> — partial derivatives of multivariate functions</li>
+        <li><strong>Jacobian &amp; Hessian matrices</strong> — higher-order derivative structures</li>
+        <li><strong>Gradient descent</strong> — optimization using computed gradients</li>
+        <li><strong>Neural network building blocks</strong> — layers and activations via AD</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Forward Mode (Dual Numbers)</h2>
+      <p>Each value carries its derivative alongside it. One forward pass computes
+      the derivative with respect to one input variable. Best for functions with
+      <strong>few inputs, many outputs</strong> (cost: O(n) passes for n inputs).</p>
+      <pre><code>(* Dual number: value + tangent *)
+type t = { v : float; d : float }
+
+(* Derivative of x² + sin(x) at x = π/4 *)
+let f x = Forward.(x * x + sin x)
+let deriv = Forward.diff f (Float.pi /. 4.0)
+(* deriv ≈ 2·(π/4) + cos(π/4) ≈ 2.278 *)</code></pre>
+    </section>
+
+    <section>
+      <h2>Reverse Mode (Backpropagation)</h2>
+      <p>Builds a computation graph during the forward pass, then propagates
+      gradients backward. One reverse pass computes derivatives with respect to
+      <strong>all inputs</strong>. Best for functions with <strong>many inputs,
+      few outputs</strong> — exactly the case for loss functions in ML.</p>
+      <pre><code>(* Build computation graph *)
+let x = Reverse.var 2.0
+let y = Reverse.var 3.0
+let z = Reverse.(x * y + sin x)
+
+(* Backpropagate from z *)
+let () = Reverse.backward z
+let dz_dx = Reverse.grad x   (* ∂z/∂x = y + cos(x) *)
+let dz_dy = Reverse.grad y   (* ∂z/∂y = x *)</code></pre>
+    </section>
+
+    <section>
+      <h2>Key Functions</h2>
+      <h3>Forward Module</h3>
+      <table>
+        <tr><th>Function</th><th>Description</th></tr>
+        <tr><td><code>var x</code></td><td>Create independent variable (derivative = 1)</td></tr>
+        <tr><td><code>const x</code></td><td>Create constant (derivative = 0)</td></tr>
+        <tr><td><code>diff f x</code></td><td>Compute f'(x) via one forward pass</td></tr>
+        <tr><td><code>nth_diff n f x</code></td><td>n-th derivative (AD + finite differences)</td></tr>
+        <tr><td><code>gradient f x</code></td><td>Gradient ∇f at point x (array)</td></tr>
+        <tr><td><code>jacobian f x</code></td><td>Jacobian matrix of f : ℝⁿ → ℝᵐ</td></tr>
+        <tr><td><code>hessian f x</code></td><td>Hessian matrix of f : ℝⁿ → ℝ</td></tr>
+        <tr><td><code>directional_deriv f x v</code></td><td>Directional derivative along v</td></tr>
+      </table>
+
+      <h3>Reverse Module</h3>
+      <table>
+        <tr><th>Function</th><th>Description</th></tr>
+        <tr><td><code>var x</code></td><td>Create input node in computation graph</td></tr>
+        <tr><td><code>backward z</code></td><td>Backpropagate gradients from output z</td></tr>
+        <tr><td><code>grad x</code></td><td>Read accumulated gradient ∂z/∂x</td></tr>
+        <tr><td><code>gradient f x</code></td><td>Gradient via single reverse pass</td></tr>
+        <tr><td><code>grad_descent f x0 ~lr ~steps</code></td><td>Minimize f by gradient descent</td></tr>
+      </table>
+
+      <h3>Supported Operations</h3>
+      <table>
+        <tr><th>Category</th><th>Operations</th></tr>
+        <tr><td>Arithmetic</td><td><code>+ - * / neg abs pow</code></td></tr>
+        <tr><td>Trigonometric</td><td><code>sin cos tan asin acos atan atan2</code></td></tr>
+        <tr><td>Hyperbolic</td><td><code>sinh cosh tanh</code></td></tr>
+        <tr><td>Exponential</td><td><code>exp log sqrt</code></td></tr>
+        <tr><td>Activations</td><td><code>sigmoid relu softplus</code></td></tr>
+      </table>
+    </section>
+
+    <section>
+      <h2>Forward vs Reverse Mode</h2>
+      <table>
+        <tr><th></th><th>Forward Mode</th><th>Reverse Mode</th></tr>
+        <tr><td>Mechanism</td><td>Dual numbers (value + tangent)</td><td>Computation graph + backprop</td></tr>
+        <tr><td>Cost per pass</td><td>One ∂f/∂xᵢ</td><td>All ∂f/∂xᵢ</td></tr>
+        <tr><td>Best for</td><td>f : ℝ → ℝᵐ (few inputs)</td><td>f : ℝⁿ → ℝ (few outputs)</td></tr>
+        <tr><td>Memory</td><td>O(1) extra</td><td>O(ops) — stores graph</td></tr>
+        <tr><td>Use case</td><td>Jacobian columns, sensitivities</td><td>Loss function gradients (ML)</td></tr>
+      </table>
+    </section>
+
+    <section>
+      <h2>When to Use</h2>
+      <ul>
+        <li><strong>Machine learning</strong> — training neural networks via backpropagation</li>
+        <li><strong>Scientific computing</strong> — sensitivities in simulations and ODEs</li>
+        <li><strong>Optimization</strong> — gradient-based minimization (Newton, L-BFGS)</li>
+        <li><strong>Probabilistic programming</strong> — gradient estimation in inference</li>
+        <li><strong>Physics engines</strong> — differentiable simulation for control</li>
+      </ul>
+    </section>
+
+    <footer>
+      <p><a href="https://github.com/sauravbhattacharya001/Ocaml-sample-code/blob/master/autodiff.ml">View source: autodiff.ml</a> (1063 lines)</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,6 +39,9 @@
             <a href="bloom-filter.html" class="nav-link">🌸 Bloom Filter</a>
             <a href="skip-list.html" class="nav-link">⏭️ Skip List</a>
             <a href="huffman.html" class="nav-link">📦 Huffman Coding</a>
+            <a href="rope.html" class="nav-link">🪢 Rope</a>
+            <a href="autodiff.html" class="nav-link">🧮 Automatic Differentiation</a>
+            <a href="sat-solver.html" class="nav-link">✅ SAT Solver</a>
         </div>
         <div class="nav-section">
             <div class="nav-title">Reference</div>

--- a/docs/rope.html
+++ b/docs/rope.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Rope Data Structure — OCaml Sample Code</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav><a href="index.html">← Home</a></nav>
+  <main>
+    <h1>🪢 Rope</h1>
+    <p class="subtitle">Balanced binary tree of strings for efficient text editing</p>
+
+    <section>
+      <h2>Overview</h2>
+      <p>A <strong>rope</strong> is a binary tree where leaves hold short strings and
+      internal nodes cache the total length of their left subtree. This gives
+      <strong>O(log n) concatenation, insertion, and deletion</strong> instead of the
+      O(n) copies required by flat strings. Ropes are the backbone of modern text
+      editors like VS Code, Xi, and Lapce.</p>
+      <p>This implementation includes automatic balancing (Fibonacci-based rebalancing),
+      line-aware indexing, and a full functional API.</p>
+    </section>
+
+    <section>
+      <h2>Concepts Demonstrated</h2>
+      <ul>
+        <li><strong>Algebraic data types</strong> — tree structure with Leaf / Node variants</li>
+        <li><strong>Persistent data structures</strong> — immutable tree with structural sharing</li>
+        <li><strong>Weight-balanced trees</strong> — cached subtree sizes for O(log n) indexing</li>
+        <li><strong>Fibonacci rebalancing</strong> — threshold-based tree restructuring</li>
+        <li><strong>Higher-order functions</strong> — fold, map, iter over character sequences</li>
+        <li><strong>Pattern matching</strong> — recursive tree traversal</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>How It Works</h2>
+      <pre><code>(* Tree structure *)
+type t =
+  | Leaf of string            (* up to max_leaf chars *)
+  | Node of { left; right;
+              weight;         (* length of left subtree *)
+              len; depth }
+
+(* Build a rope from a string *)
+let r = Rope.of_string "Hello, world!"
+
+(* O(1) concatenation — just creates a new root node *)
+let r2 = Rope.concat r (Rope.of_string " Goodbye!")
+
+(* O(log n) character access *)
+let ch = Rope.index r2 7      (* → 'w' *)
+
+(* O(log n) insert at position *)
+let r3 = Rope.insert r2 5 " beautiful"
+
+(* O(log n) delete range *)
+let r4 = Rope.delete r3 0 6   (* remove "Hello," *)</code></pre>
+    </section>
+
+    <section>
+      <h2>Key Functions</h2>
+      <table>
+        <tr><th>Function</th><th>Complexity</th><th>Description</th></tr>
+        <tr><td><code>of_string s</code></td><td>O(n)</td><td>Build balanced rope from string</td></tr>
+        <tr><td><code>to_string r</code></td><td>O(n)</td><td>Flatten rope to string</td></tr>
+        <tr><td><code>concat a b</code></td><td>O(1)</td><td>Concatenate two ropes</td></tr>
+        <tr><td><code>length r</code></td><td>O(1)</td><td>Total character count</td></tr>
+        <tr><td><code>index r i</code></td><td>O(log n)</td><td>Character at position i</td></tr>
+        <tr><td><code>substring r i len</code></td><td>O(log n + len)</td><td>Extract substring</td></tr>
+        <tr><td><code>insert r i s</code></td><td>O(log n)</td><td>Insert string at position</td></tr>
+        <tr><td><code>delete r i len</code></td><td>O(log n)</td><td>Delete range</td></tr>
+        <tr><td><code>split r i</code></td><td>O(log n)</td><td>Split into two ropes at position</td></tr>
+        <tr><td><code>balance r</code></td><td>O(n)</td><td>Rebalance using Fibonacci thresholds</td></tr>
+        <tr><td><code>is_balanced r</code></td><td>O(1)</td><td>Check balance invariant</td></tr>
+        <tr><td><code>lines r</code></td><td>O(n)</td><td>Split into lines</td></tr>
+        <tr><td><code>iter f r</code></td><td>O(n)</td><td>Apply f to each character</td></tr>
+        <tr><td><code>fold f init r</code></td><td>O(n)</td><td>Left fold over characters</td></tr>
+        <tr><td><code>map f r</code></td><td>O(n)</td><td>Map function over characters</td></tr>
+      </table>
+    </section>
+
+    <section>
+      <h2>Why Not Just Use Strings?</h2>
+      <table>
+        <tr><th>Operation</th><th>Flat String</th><th>Rope</th></tr>
+        <tr><td>Concatenation</td><td>O(n + m) — full copy</td><td>O(1) — new node</td></tr>
+        <tr><td>Insert at position</td><td>O(n) — shift + copy</td><td>O(log n) — split + concat</td></tr>
+        <tr><td>Delete range</td><td>O(n) — shift + copy</td><td>O(log n) — split + concat</td></tr>
+        <tr><td>Character access</td><td>O(1) — direct index</td><td>O(log n) — tree walk</td></tr>
+        <tr><td>Memory on edit</td><td>Full copy</td><td>Shared structure</td></tr>
+      </table>
+      <p>For documents longer than a few KB, ropes dramatically reduce the cost
+      of editing operations. The O(log n) access trade-off is rarely noticeable
+      since editors typically access characters sequentially.</p>
+    </section>
+
+    <section>
+      <h2>When to Use</h2>
+      <ul>
+        <li><strong>Text editors</strong> — fast insert/delete anywhere in large documents</li>
+        <li><strong>Version control</strong> — efficient diff and patch with structural sharing</li>
+        <li><strong>Log aggregation</strong> — concatenating many small strings without copying</li>
+        <li><strong>Undo/redo</strong> — persistent structure enables cheap snapshots</li>
+      </ul>
+    </section>
+
+    <footer>
+      <p><a href="https://github.com/sauravbhattacharya001/Ocaml-sample-code/blob/master/rope.ml">View source: rope.ml</a> (353 lines)</p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/sat-solver.html
+++ b/docs/sat-solver.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SAT Solver — OCaml Sample Code</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav><a href="index.html">← Home</a></nav>
+  <main>
+    <h1>✅ SAT Solver</h1>
+    <p class="subtitle">Boolean satisfiability via the DPLL algorithm</p>
+
+    <section>
+      <h2>Overview</h2>
+      <p>A <strong>SAT solver</strong> determines whether a Boolean formula in
+      <strong>conjunctive normal form (CNF)</strong> has a satisfying assignment.
+      This is the canonical NP-complete problem — the first problem proven
+      NP-complete (Cook–Levin, 1971). Despite worst-case exponential time, modern
+      SAT solvers handle millions of variables using clever heuristics.</p>
+      <p>This implementation uses the <strong>DPLL</strong> (Davis–Putnam–Logemann–Loveland)
+      algorithm with unit propagation, pure literal elimination, and backtracking.
+      Includes support for DIMACS CNF parsing and solution verification.</p>
+    </section>
+
+    <section>
+      <h2>Concepts Demonstrated</h2>
+      <ul>
+        <li><strong>Algebraic data types</strong> — literals as <code>Pos | Neg</code> variants</li>
+        <li><strong>Pattern matching</strong> — clause evaluation and propagation</li>
+        <li><strong>Backtracking search</strong> — systematic exploration of variable assignments</li>
+        <li><strong>Unit propagation</strong> — forced assignments from unit clauses</li>
+        <li><strong>Pure literal elimination</strong> — variables appearing in only one polarity</li>
+        <li><strong>Immutable maps</strong> — persistent assignment tracking for backtracking</li>
+        <li><strong>NP-completeness</strong> — the foundation of computational complexity</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>The DPLL Algorithm</h2>
+      <pre><code>(* CNF formula: (a ∨ ¬b) ∧ (b ∨ c) ∧ (¬a ∨ ¬c) *)
+let formula = [
+  [Pos 1; Neg 2];       (* a ∨ ¬b *)
+  [Pos 2; Pos 3];       (* b ∨ c  *)
+  [Neg 1; Neg 3];       (* ¬a ∨ ¬c *)
+]
+
+(* DPLL proceeds by:
+   1. Unit propagation — if a clause has one unset literal, force it
+   2. Pure literal elim — if a var appears only positive (or only
+      negative), assign it to satisfy all those clauses
+   3. Choose — pick an unassigned variable, try true then false
+   4. Backtrack — if a conflict is found, undo and try the other branch
+*)
+
+match solve formula with
+| Some assignment -> (* satisfying assignment found *)
+| None            -> (* formula is unsatisfiable *)</code></pre>
+    </section>
+
+    <section>
+      <h2>Key Functions</h2>
+      <table>
+        <tr><th>Function</th><th>Description</th></tr>
+        <tr><td><code>solve formula</code></td><td>Find satisfying assignment or return None</td></tr>
+        <tr><td><code>unit_propagate</code></td><td>Find and propagate unit clauses (single-literal)</td></tr>
+        <tr><td><code>pure_literal_elim</code></td><td>Assign variables appearing in only one polarity</td></tr>
+        <tr><td><code>simplify</code></td><td>Remove satisfied clauses and falsified literals</td></tr>
+        <tr><td><code>variables</code></td><td>Collect all variables in a formula</td></tr>
+        <tr><td><code>eval_clause</code></td><td>Evaluate clause under partial assignment</td></tr>
+        <tr><td><code>eval_formula</code></td><td>Evaluate entire formula under assignment</td></tr>
+        <tr><td><code>parse_dimacs</code></td><td>Parse standard DIMACS CNF format</td></tr>
+        <tr><td><code>verify</code></td><td>Verify a solution against the original formula</td></tr>
+      </table>
+    </section>
+
+    <section>
+      <h2>DPLL Optimizations</h2>
+      <table>
+        <tr><th>Technique</th><th>Effect</th></tr>
+        <tr><td>Unit propagation</td><td>Forced deductions — dramatically prunes the search tree</td></tr>
+        <tr><td>Pure literal elimination</td><td>Variables that only appear positive (or negative) can be set freely</td></tr>
+        <tr><td>Early termination</td><td>Stop as soon as a clause is falsified (no need to check the rest)</td></tr>
+        <tr><td>Immutable assignments</td><td>Backtracking is free — just discard the current map</td></tr>
+      </table>
+    </section>
+
+    <section>
+      <h2>Applications of SAT Solving</h2>
+      <ul>
+        <li><strong>Hardware verification</strong> — checking circuit correctness (Intel, AMD)</li>
+        <li><strong>Software verification</strong> — bounded model checking for bug finding</li>
+        <li><strong>Planning &amp; scheduling</strong> — encoding constraints as Boolean formulas</li>
+        <li><strong>Cryptanalysis</strong> — attacking ciphers by encoding as SAT</li>
+        <li><strong>Package managers</strong> — dependency resolution (apt, opam)</li>
+        <li><strong>Sudoku &amp; puzzles</strong> — constraint satisfaction via CNF encoding</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>CNF Format</h2>
+      <pre><code>(* DIMACS CNF — standard interchange format *)
+(* p cnf &lt;num_vars&gt; &lt;num_clauses&gt; *)
+(* Each line: space-separated literals, 0-terminated *)
+(* Positive int = positive literal, negative = negation *)
+
+p cnf 3 3
+1 -2 0       (* a ∨ ¬b *)
+2 3 0        (* b ∨ c  *)
+-1 -3 0      (* ¬a ∨ ¬c *)
+
+(* Parse with: parse_dimacs input_string *)</code></pre>
+    </section>
+
+    <footer>
+      <p><a href="https://github.com/sauravbhattacharya001/Ocaml-sample-code/blob/master/sat_solver.ml">View source: sat_solver.ml</a> (389 lines)</p>
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Adds 3 new documentation pages to the GitHub Pages docs site, covering some of the most advanced undocumented modules (72 of 90 .ml files still lack doc pages).

## New Pages
- **autodiff.html** — Automatic differentiation: dual numbers (forward mode), computation graphs (reverse mode), gradient/Jacobian/Hessian, optimization, neural net building blocks
- **rope.html** — Rope data structure: O(log n) concat/insert/delete, weight-balanced tree, Fibonacci rebalancing, text editor use cases
- **sat-solver.html** — SAT solver: DPLL algorithm, unit propagation, pure literal elimination, DIMACS CNF format, applications

All pages follow the existing style with overview, concepts, code examples, function tables, and use-case lists. Nav links added to index.html sidebar.