### PR TITLE
fix: add 6 missing source files to Makefile, install alcotest in CI

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install OCaml dependencies
         run: |
-          opam install bisect_ppx ocamlfind --yes
+          opam install bisect_ppx ocamlfind alcotest --yes
           eval $(opam env)
 
       - name: Build all programs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          opam install bisect_ppx ocamlfind --yes
+          opam install bisect_ppx ocamlfind alcotest --yes
           eval $(opam env)
 
       - name: Build all programs

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,16 @@ SOURCES_PLAIN = hello.ml fibonacci.ml factor.ml list_last_elem.ml bst.ml \
 	comonad.ml constraint.ml crdt.ml deque.ml finger_tree.ml \
 	genetic.ml monad_transformers.ml persistent_vector.ml \
 	random_access_list.ml raytracer.ml stm.ml delimited_cont.ml \
-	neural_network.ml lsystem.ml
+	neural_network.ml lsystem.ml cellular_automata.ml memoize.ml \
+	signal_processing.ml spreadsheet.ml
 
 # Sources that require ocamlfind + external packages
-SOURCES_PKG = csv.ml free_monad.ml actor.ml
+SOURCES_PKG = csv.ml free_monad.ml actor.ml kd_tree.ml tensor.ml
 # csv.ml needs: ocamlfind ocamlopt -package str -linkpkg csv.ml -o csv
 # free_monad.ml needs: ocamlfind ocamlopt -package str -linkpkg free_monad.ml -o free_monad
 # actor.ml needs: ocamlfind ocamlopt -package unix -linkpkg actor.ml -o actor
+# kd_tree.ml needs: ocamlfind ocamlopt -package alcotest -linkpkg kd_tree.ml -o kd_tree
+# tensor.ml needs: ocamlfind ocamlopt -package alcotest -linkpkg tensor.ml -o tensor
 
 SOURCES = $(SOURCES_PLAIN) $(SOURCES_PKG)
 TARGETS_PLAIN = $(SOURCES_PLAIN:.ml=)
@@ -54,6 +57,14 @@ free_monad: free_monad.ml
 # actor needs the unix package via ocamlfind
 actor: actor.ml
 	ocamlfind $(OCAML) -package unix -linkpkg $< -o $@
+
+# kd_tree needs the alcotest package via ocamlfind
+kd_tree: kd_tree.ml
+	ocamlfind $(OCAML) -package alcotest -linkpkg $< -o $@
+
+# tensor needs the alcotest package via ocamlfind
+tensor: tensor.ml
+	ocamlfind $(OCAML) -package alcotest -linkpkg $< -o $@
 
 test: test_all
 	@echo "=== Running tests ==="


### PR DESCRIPTION
## Problem

6 \.ml\ files exist on disk but are not listed in the Makefile:

| File | Lines | Dependencies |
|------|-------|-------------|
| \cellular_automata.ml\ | 509 | none |
| \memoize.ml\ | 289 | none |
| \signal_processing.ml\ | 496 | none |
| \spreadsheet.ml\ | 1737 | none |
| \kd_tree.ml\ | 808 | alcotest |
| \	ensor.ml\ | 1232 | alcotest |

This means \make all\ skips building them, \make clean\ doesn't clean their artifacts, and CI never verifies they compile.

## Fix

- Added 4 plain sources to \SOURCES_PLAIN\
- Added \kd_tree.ml\ and \	ensor.ml\ to \SOURCES_PKG\ with dedicated build rules (need \ocamlfind + alcotest\)
- Added \lcotest\ to \opam install\ in CI workflow and copilot-setup-steps