### PR TITLE
fix: sanitize innerHTML against XSS in explorer & complexity pages

### DIFF
--- a/docs/complexity.html
+++ b/docs/complexity.html
@@ -287,6 +287,13 @@ function colorClass(c) {
 
 function catClass(c) { return 'cat-' + c.toLowerCase().replace(/[^a-z]/g, '-').replace(/-+/g, '-'); }
 
+// Prevent XSS — escape data before interpolating into innerHTML
+function escapeHtml(s) {
+    if (typeof s !== 'string') return String(s);
+    return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+            .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
 // Populate category filter
 const cats = [...new Set(DATA.map(d => d.cat))].sort();
 const catSel = document.getElementById('catFilter');
@@ -317,13 +324,13 @@ function render() {
 
     const tbody = document.getElementById('tableBody');
     tbody.innerHTML = filtered.map(d => `<tr>
-        <td><strong>${d.name}</strong></td>
-        <td><span class="cat-badge ${catClass(d.cat)}">${d.cat}</span></td>
-        <td style="color:var(--text-dim);font-size:0.82rem">${d.op}</td>
-        <td><span class="big-o ${colorClass(d.avg)}">${d.avg}</span></td>
-        <td><span class="big-o ${colorClass(d.worst)}">${d.worst}</span></td>
-        <td><span class="big-o ${colorClass(d.space)}">${d.space}</span></td>
-        <td><a href="https://github.com/sauravbhattacharya001/Ocaml-sample-code/blob/main/${d.file}">${d.file}</a></td>
+        <td><strong>${escapeHtml(d.name)}</strong></td>
+        <td><span class="cat-badge ${catClass(d.cat)}">${escapeHtml(d.cat)}</span></td>
+        <td style="color:var(--text-dim);font-size:0.82rem">${escapeHtml(d.op)}</td>
+        <td><span class="big-o ${colorClass(d.avg)}">${escapeHtml(d.avg)}</span></td>
+        <td><span class="big-o ${colorClass(d.worst)}">${escapeHtml(d.worst)}</span></td>
+        <td><span class="big-o ${colorClass(d.space)}">${escapeHtml(d.space)}</span></td>
+        <td><a href="https://github.com/sauravbhattacharya001/Ocaml-sample-code/blob/main/${encodeURI(d.file)}">${escapeHtml(d.file)}</a></td>
     </tr>`).join('');
 
     // Stats
@@ -335,7 +342,7 @@ function render() {
         <div class="stat-card"><div class="stat-num">${filtered.length}</div><div class="stat-label">Algorithms</div></div>
         <div class="stat-card"><div class="stat-num">${Object.keys(catCounts).length}</div><div class="stat-label">Categories</div></div>
         <div class="stat-card"><div class="stat-num">${o1Count}</div><div class="stat-label">O(1) Average</div></div>
-        <div class="stat-card"><div class="stat-num">${topCat ? topCat[0] : '—'}</div><div class="stat-label">Most Entries</div></div>
+        <div class="stat-card"><div class="stat-num">${topCat ? escapeHtml(topCat[0]) : '—'}</div><div class="stat-label">Most Entries</div></div>
     `;
 }
 

--- a/docs/explorer.html
+++ b/docs/explorer.html
@@ -228,6 +228,13 @@ const CATEGORIES = {
 
 const DIFF_ORDER = { beginner: 0, intermediate: 1, advanced: 2 };
 
+// Prevent XSS — escape data before interpolating into innerHTML
+function escapeHtml(s) {
+    if (typeof s !== 'string') return String(s);
+    return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
+            .replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
 let activeCategory = "all";
 let expandedCard = null;
 
@@ -272,21 +279,28 @@ function render() {
     }
 
     grid.innerHTML = filtered.map(ex => {
-        const badgeClass = `badge-${ex.difficulty}`;
+        const badgeClass = `badge-${escapeHtml(ex.difficulty)}`;
         const isExpanded = expandedCard === ex.name;
+        const eName = escapeHtml(ex.name);
+        const eTitle = escapeHtml(ex.title);
+        const eDesc = escapeHtml(ex.desc);
+        const eDiff = escapeHtml(ex.difficulty);
+        const catInfo = CATEGORIES[ex.category];
+        const catIcon = catInfo ? catInfo.icon : '';
+        const catLabel = catInfo ? escapeHtml(catInfo.label) : escapeHtml(ex.category);
         return `
-            <div class="example-card ${isExpanded ? 'expanded' : ''}" data-name="${ex.name}" onclick="toggleCard('${ex.name}')">
+            <div class="example-card ${isExpanded ? 'expanded' : ''}" data-name="${eName}">
                 <div class="card-header">
-                    <span class="card-title">${ex.title}</span>
-                    <span class="card-badge ${badgeClass}">${ex.difficulty}</span>
+                    <span class="card-title">${eTitle}</span>
+                    <span class="card-badge ${badgeClass}">${eDiff}</span>
                 </div>
-                <div class="card-desc">${ex.desc}</div>
+                <div class="card-desc">${eDesc}</div>
                 <div class="card-meta">
-                    <span class="card-tag">${CATEGORIES[ex.category]?.icon || ""} ${CATEGORIES[ex.category]?.label || ex.category}</span>
+                    <span class="card-tag">${catIcon} ${catLabel}</span>
                     <span class="card-lines">${ex.lines} lines</span>
-                    ${ex.docPage ? `<a class="card-doc-link" href="${ex.docPage}" onclick="event.stopPropagation()">📖 Docs</a>` : ''}
+                    ${ex.docPage ? `<a class="card-doc-link" href="${escapeHtml(ex.docPage)}" data-doc-link>📖 Docs</a>` : ''}
                 </div>
-                <div class="code-preview ${isExpanded ? 'visible' : ''}" id="code-${ex.name}">
+                <div class="code-preview ${isExpanded ? 'visible' : ''}" id="code-${eName}">
                     <pre>${isExpanded ? '⏳ Loading...' : ''}</pre>
                 </div>
             </div>`;
@@ -329,7 +343,7 @@ function renderFilters() {
     counts.all = EXAMPLES.length;
 
     container.innerHTML = Object.entries(CATEGORIES).map(([key, cat]) =>
-        `<button class="filter-btn ${activeCategory === key ? 'active' : ''}" onclick="setCategory('${key}')">${cat.icon} ${cat.label} (${counts[key] || 0})</button>`
+        `<button class="filter-btn ${activeCategory === key ? 'active' : ''}" data-category="${escapeHtml(key)}">${cat.icon} ${escapeHtml(cat.label)} (${counts[key] || 0})</button>`
     ).join("");
 }
 
@@ -340,9 +354,21 @@ function setCategory(cat) {
     render();
 }
 
-// Event listeners
+// Event listeners — use event delegation instead of inline onclick (XSS-safe)
 document.getElementById("search").addEventListener("input", () => { expandedCard = null; render(); });
 document.getElementById("sort-by").addEventListener("change", render);
+
+document.getElementById("grid").addEventListener("click", function(e) {
+    // Don't toggle card when clicking doc links
+    if (e.target.hasAttribute('data-doc-link')) return;
+    const card = e.target.closest('.example-card');
+    if (card) toggleCard(card.getAttribute('data-name'));
+});
+
+document.getElementById("category-filters").addEventListener("click", function(e) {
+    const btn = e.target.closest('.filter-btn');
+    if (btn) setCategory(btn.getAttribute('data-category'));
+});
 
 // Boot
 renderFilters();


### PR DESCRIPTION
Adds escapeHtml() and sanitizes all data interpolated into innerHTML template literals. Replaces inline onclick handlers with event delegation in explorer.html. Uses encodeURI for href attributes.