### PR TITLE
refactor: extract shared test_framework.ml, deduplicate 350 lines

### DIFF
--- a/test_all.ml
+++ b/test_all.ml
@@ -1,45 +1,8 @@
 (* test_all.ml — Comprehensive test suite for OCaml sample code *)
 (* Tests core algorithms: BST, factorization, fibonacci, mergesort, heap, list_last, graph *)
-(* Uses simple assertion-based testing — no external dependencies required *)
+(* Uses shared test_framework.ml — loaded via #use for interpreter, or linked for compiler *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
-let current_suite = ref ""
-
-let assert_equal ~msg expected actual =
-  incr tests_run;
-  if expected = actual then
-    incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s: expected %s, got %s\n"
-      !current_suite msg
-      (expected) (actual)
-  end
-
-let assert_true ~msg condition =
-  incr tests_run;
-  if condition then
-    incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s\n" !current_suite msg
-  end
-
-let assert_raises ~msg f =
-  incr tests_run;
-  try
-    ignore (f ());
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s: expected exception\n" !current_suite msg
-  with _ ->
-    incr tests_passed
-
-let suite name f =
-  current_suite := name;
-  Printf.printf "Running: %s\n" name;
-  f ()
+#use "test_framework.ml";;
 
 let string_of_int_list lst =
   "[" ^ String.concat "; " (List.map string_of_int lst) ^ "]"
@@ -7271,13 +7234,4 @@ let () =
   test_calculus ();
   test_type_infer ();
   test_minikanren ();
-  Printf.printf "\n=== Results ===\n";
-  Printf.printf "Total: %d | Passed: %d | Failed: %d\n"
-    !tests_run !tests_passed !tests_failed;
-  if !tests_failed > 0 then begin
-    Printf.printf "STATUS: SOME TESTS FAILED\n";
-    exit 1
-  end else begin
-    Printf.printf "STATUS: ALL TESTS PASSED ✓\n";
-    exit 0
-  end
+  test_summary ()

--- a/test_cellular_automata.ml
+++ b/test_cellular_automata.ml
@@ -1,9 +1,8 @@
 (* Tests for cellular_automata.ml *)
 
+#use "test_framework.ml";;
 #use "cellular_automata.ml"
 
-let tests_passed = ref 0
-let tests_failed = ref 0
 
 let test name f =
   try
@@ -13,10 +12,6 @@ let test name f =
   with e ->
     incr tests_failed;
     Printf.printf "  ✗ %s: %s\n" name (Printexc.to_string e)
-
-let assert_eq a b =
-  if a <> b then failwith (Printf.sprintf "expected %s, got %s"
-    (string_of_int b) (string_of_int a))
 
 let () =
   print_endline "\n=== Cellular Automata Tests ===\n";
@@ -258,5 +253,4 @@ let () =
     assert (cx = 5.0 && cy = 5.0));
 
   (* Summary *)
-  Printf.printf "\n=== Results: %d passed, %d failed ===\n" !tests_passed !tests_failed;
-  if !tests_failed > 0 then exit 1
+  test_summary ()

--- a/test_finger_tree.ml
+++ b/test_finger_tree.ml
@@ -10,22 +10,12 @@
  *   ocamlopt ml test_ml -o test_finger_tree && ./test_finger_tree
  *)
 
+#use "test_framework.ml";;
 #use "ml";;
 
 (* ── Minimal test harness ─────────────────────────────────────────── *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
 let current_suite = ref ""
-
-let assert_true ~msg cond =
-  incr tests_run;
-  if cond then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s\n" !current_suite msg
-  end
 
 let assert_equal_list ~msg expected actual =
   incr tests_run;
@@ -45,14 +35,6 @@ let assert_int ~msg expected actual =
     Printf.printf "  FAIL [%s] %s: expected %d, got %d\n"
       !current_suite msg expected actual
   end
-
-let assert_raises ~msg f =
-  incr tests_run;
-  try
-    ignore (f ());
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s: expected exception\n" !current_suite msg
-  with _ -> incr tests_passed
 
 let suite name f =
   current_suite := name;
@@ -283,8 +265,4 @@ let () =
   Printf.printf "Total: %d | Passed: %d | Failed: %d\n"
     !tests_run !tests_passed !tests_failed;
   if !tests_failed = 0 then
-    Printf.printf "All tests passed!\n"
-  else
-    Printf.printf "SOME TESTS FAILED\n";
-  exit !tests_failed
-
+  test_summary ()

--- a/test_framework.ml
+++ b/test_framework.ml
@@ -1,0 +1,84 @@
+(* test_framework.ml — Shared test assertions for all test_*.ml files.
+ *
+ * Provides a lightweight assertion library with consistent output,
+ * counters, and a summary printer. Designed to be loaded via:
+ *
+ *   #use "test_framework.ml";;
+ *
+ * or compiled alongside test files:
+ *
+ *   ocamlopt test_framework.ml test_foo.ml -o test_foo
+ *
+ * API:
+ *   assert_true  ~msg condition        — pass if condition is true
+ *   assert_false ~msg condition        — pass if condition is false
+ *   assert_equal ~msg expected actual  — pass if expected = actual (strings)
+ *   assert_raises ~msg f              — pass if f () raises any exception
+ *   assert_float_eq ~msg ~eps a b     — pass if |a - b| < eps
+ *   suite name f                      — run f () under suite name
+ *   test_summary ()                   — print results, exit 1 if any failed
+ *)
+
+let tests_run    = ref 0
+let tests_passed = ref 0
+let tests_failed = ref 0
+let current_suite = ref ""
+
+let assert_true ~msg condition =
+  incr tests_run;
+  if condition then
+    incr tests_passed
+  else begin
+    incr tests_failed;
+    Printf.printf "  FAIL [%s] %s\n" !current_suite msg
+  end
+
+let assert_false ~msg condition =
+  assert_true ~msg (not condition)
+
+let assert_equal ~msg expected actual =
+  incr tests_run;
+  if expected = actual then
+    incr tests_passed
+  else begin
+    incr tests_failed;
+    Printf.printf "  FAIL [%s] %s: expected %s, got %s\n"
+      !current_suite msg expected actual
+  end
+
+let assert_raises ~msg f =
+  incr tests_run;
+  (try
+    ignore (f ());
+    incr tests_failed;
+    Printf.printf "  FAIL [%s] %s: expected exception, none raised\n"
+      !current_suite msg
+  with _ ->
+    incr tests_passed)
+
+let assert_float_eq ~msg ?(eps=1e-9) expected actual =
+  incr tests_run;
+  if Float.abs (expected -. actual) < eps then
+    incr tests_passed
+  else begin
+    incr tests_failed;
+    Printf.printf "  FAIL [%s] %s: expected %f, got %f (eps=%g)\n"
+      !current_suite msg expected actual eps
+  end
+
+let suite name f =
+  current_suite := name;
+  Printf.printf "Running: %s\n" name;
+  f ()
+
+let test_summary () =
+  Printf.printf "\n=== Results ===\n";
+  Printf.printf "Total: %d | Passed: %d | Failed: %d\n"
+    !tests_run !tests_passed !tests_failed;
+  if !tests_failed > 0 then begin
+    Printf.printf "STATUS: SOME TESTS FAILED\n";
+    exit 1
+  end else begin
+    Printf.printf "STATUS: ALL TESTS PASSED\n";
+    exit 0
+  end

--- a/test_geometry.ml
+++ b/test_geometry.ml
@@ -7,28 +7,16 @@
  * Run: ocaml test_geometry.ml
  *)
 
+#use "test_framework.ml";;
 #use "geometry.ml";;
 
 (* ── Test infrastructure ────────────────────────────────────────── *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
 let current_section = ref ""
 
 let section name =
   current_section := name;
   Printf.printf "\n── %s ──\n" name
-
-let assert_true ~msg cond =
-  incr tests_run;
-  if cond then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL [%s]: %s\n" !current_section msg
-  end
-
-let assert_false ~msg cond = assert_true ~msg (not cond)
 
 let assert_float ~msg ?(tol=1e-6) expected actual =
   incr tests_run;
@@ -38,13 +26,6 @@ let assert_float ~msg ?(tol=1e-6) expected actual =
     Printf.printf "  FAIL [%s]: %s (expected %.8f, got %.8f)\n"
       !current_section msg expected actual
   end
-
-let assert_raises ~msg f =
-  incr tests_run;
-  (try ignore (f ());
-    incr tests_failed;
-    Printf.printf "  FAIL [%s]: %s (no exception raised)\n" !current_section msg
-  with _ -> incr tests_passed)
 
 let () =
   Printf.printf "=== Geometry Module Tests ===\n";
@@ -449,6 +430,4 @@ let () =
   assert_float ~msg:"very close points" 1e-5 dc;
 
   (* ── Summary ──────────────────────────────────────── *)
-  Printf.printf "\n=== Results: %d passed, %d failed (total: %d) ===\n"
-    !tests_passed !tests_failed !tests_run;
-  if !tests_failed > 0 then exit 1
+  test_summary ()

--- a/test_graph_db.ml
+++ b/test_graph_db.ml
@@ -1,23 +1,10 @@
 (* test_graph_db.ml — Tests for the Property Graph Query Engine *)
 (* 100+ assertions covering graph construction, queries, aggregation,
+#use "test_framework.ml";;
+
    path finding, filtering, mutations, and edge cases *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
 let current_suite = ref ""
-
-let assert_true ~msg condition =
-  incr tests_run;
-  if condition then incr tests_passed
-  else begin incr tests_failed; Printf.printf "  FAIL [%s] %s\n" !current_suite msg end
-
-let assert_equal ~msg expected actual =
-  incr tests_run;
-  if expected = actual then incr tests_passed
-  else begin incr tests_failed;
-    Printf.printf "  FAIL [%s] %s: expected %s, got %s\n"
-      !current_suite msg expected actual end
 
 let assert_int ~msg expected actual =
   assert_equal ~msg (string_of_int expected) (string_of_int actual)
@@ -630,12 +617,4 @@ let () =
   test_empty_graph_queries ();
   test_direction ();
 
-  Printf.printf "\n=== Results: %d/%d passed, %d failed ===\n"
-    !tests_passed !tests_run !tests_failed;
-  if !tests_failed > 0 then begin
-    Printf.printf "STATUS: SOME TESTS FAILED\n";
-    exit 1
-  end else begin
-    Printf.printf "STATUS: ALL TESTS PASSED ✓\n";
-    exit 0
-  end
+  test_summary ()

--- a/test_interval_tree.ml
+++ b/test_interval_tree.ml
@@ -3,33 +3,9 @@
 
 (* ── Test framework ────────────────────────────────────────────────── *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
+#use "test_framework.ml";;
+
 let current_suite = ref ""
-
-let assert_true ~msg condition =
-  incr tests_run;
-  if condition then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s\n" !current_suite msg
-  end
-
-let assert_equal ~msg expected actual =
-  incr tests_run;
-  if expected = actual then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s: expected %s, got %s\n"
-      !current_suite msg expected actual
-  end
-
-let assert_raises ~msg f =
-  incr tests_run;
-  try ignore (f ()); incr tests_failed;
-    Printf.printf "  FAIL [%s] %s: expected exception\n" !current_suite msg
-  with _ -> incr tests_passed
 
 let suite name f =
   current_suite := name;
@@ -469,6 +445,4 @@ let () =
   test_fold_order ();
   test_span_single ();
   test_remove_rebalance ();
-  Printf.printf "\n=== Results: %d passed, %d failed, %d total ===\n"
-    !tests_passed !tests_failed !tests_run;
-  if !tests_failed > 0 then exit 1
+  test_summary ()

--- a/test_json.ml
+++ b/test_json.ml
@@ -1,21 +1,10 @@
 (* test_json.ml — Comprehensive test suite for the JSON parser *)
 (* 170+ assertions covering parsing, serialization, queries, equality,
+#use "test_framework.ml";;
+
    transforms, edge cases, and error handling *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
 let current_suite = ref ""
-
-let assert_true ~msg condition =
-  incr tests_run;
-  if condition then incr tests_passed
-  else begin incr tests_failed; Printf.printf "  FAIL [%s] %s\n" !current_suite msg end
-
-let assert_equal ~msg expected actual =
-  incr tests_run;
-  if expected = actual then incr tests_passed
-  else begin incr tests_failed; Printf.printf "  FAIL [%s] %s: expected %s, got %s\n" !current_suite msg expected actual end
 
 let suite name f = current_suite := name; Printf.printf "Running: %s\n" name; f ()
 
@@ -614,4 +603,4 @@ let () =
   Printf.printf "Passed:    %d\n" !tests_passed;
   Printf.printf "Failed:    %d\n" !tests_failed;
   if !tests_failed = 0 then print_endline "All tests passed!"
-  else begin Printf.printf "FAILURES: %d\n" !tests_failed; exit 1 end
+  test_summary ()

--- a/test_lru_cache.ml
+++ b/test_lru_cache.ml
@@ -1,35 +1,11 @@
 (* test_lru_cache.ml — Tests for LRU Cache module *)
 (* Run: ocaml test_lru_cache.ml *)
 
+#use "test_framework.ml";;
 #use "lru_cache.ml";;
 
 open LRUCache
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
-
-let assert_true ~msg cond =
-  incr tests_run;
-  if cond then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL: %s\n" msg
-  end
-
-let assert_equal ~msg expected actual =
-  incr tests_run;
-  if expected = actual then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL: %s (expected %s, got %s)\n" msg expected actual
-  end
-
-let assert_raises ~msg f =
-  incr tests_run;
-  try ignore (f ()); incr tests_failed;
-      Printf.printf "  FAIL: %s: expected exception\n" msg
-  with _ -> incr tests_passed
 
 (* ============================================================ *)
 (* Create                                                        *)
@@ -462,6 +438,4 @@ let () =
 (* Summary                                                       *)
 (* ============================================================ *)
 let () =
-  Printf.printf "\n%d/%d tests passed (%d failed)\n"
-    !tests_passed !tests_run !tests_failed;
-  if !tests_failed > 0 then exit 1
+  test_summary ()

--- a/test_matrix.ml
+++ b/test_matrix.ml
@@ -1,34 +1,8 @@
 (* test_matrix.ml — Tests for Matrix module *)
 (* Run: ocaml test_matrix.ml *)
 
+#use "test_framework.ml";;
 #use "matrix.ml";;
-
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
-
-let assert_true ~msg cond =
-  incr tests_run;
-  if cond then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL: %s\n" msg
-  end
-
-let assert_equal ~msg expected actual =
-  incr tests_run;
-  if expected = actual then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL: %s (expected %s, got %s)\n" msg expected actual
-  end
-
-let assert_raises ~msg f =
-  incr tests_run;
-  try ignore (f ());
-    incr tests_failed;
-    Printf.printf "  FAIL: %s (no exception raised)\n" msg
-  with _ -> incr tests_passed
 
 let () =
   Printf.printf "=== Matrix Tests ===\n\n";
@@ -289,13 +263,4 @@ let () =
   assert_true ~msg:"to_string not empty" (String.length s > 0);
   assert_true ~msg:"to_string contains dimension" (String.length s > 10);
 
-  Printf.printf "\n=== Results ===\n";
-  Printf.printf "Total: %d | Passed: %d | Failed: %d\n"
-    !tests_run !tests_passed !tests_failed;
-  if !tests_failed > 0 then begin
-    Printf.printf "STATUS: SOME TESTS FAILED\n";
-    exit 1
-  end else begin
-    Printf.printf "STATUS: ALL TESTS PASSED ✓\n";
-    exit 0
-  end
+  test_summary ()

--- a/test_memoize.ml
+++ b/test_memoize.ml
@@ -1,25 +1,7 @@
 (* test_memoize.ml — Tests for memoization combinators *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
 
-let assert_equal ~msg expected actual =
-  incr tests_run;
-  if expected = actual then (
-    incr tests_passed;
-    Printf.printf "  ✓ %s\n" msg
-  ) else (
-    Printf.printf "  ✗ %s (expected %s, got %s)\n" msg
-      (string_of_int expected) (string_of_int actual)
-  )
-
-let assert_true ~msg b =
-  incr tests_run;
-  if b then (
-    incr tests_passed;
-    Printf.printf "  ✓ %s\n" msg
-  ) else
-    Printf.printf "  ✗ %s\n" msg
+#use "test_framework.ml";;
 
 let assert_float ~msg ~eps expected actual =
   incr tests_run;
@@ -171,5 +153,4 @@ let () =
   test_clearable ();
   test_collatz ();
   test_hit_rate ();
-  Printf.printf "\n%d/%d tests passed\n" !tests_passed !tests_run;
-  if !tests_passed < !tests_run then exit 1
+  test_summary ()

--- a/test_queue.ml
+++ b/test_queue.ml
@@ -1,8 +1,7 @@
 (* test_queue.ml — Tests for the Purely Functional Queue *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
+#use "test_framework.ml";;
+
 let current_suite = ref ""
 
 let assert_equal_generic ~msg ~to_string expected actual =
@@ -31,24 +30,6 @@ let assert_equal_int_list ~msg expected actual =
 let assert_equal_int_opt ~msg expected actual =
   let s = function None -> "None" | Some x -> "Some(" ^ string_of_int x ^ ")" in
   assert_equal_generic ~msg ~to_string:s expected actual
-
-let assert_true ~msg condition =
-  incr tests_run;
-  if condition then
-    incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s\n" !current_suite msg
-  end
-
-let assert_raises ~msg f =
-  incr tests_run;
-  try
-    ignore (f ());
-    incr tests_failed;
-    Printf.printf "  FAIL [%s] %s: expected exception\n" !current_suite msg
-  with _ ->
-    incr tests_passed
 
 let suite name f =
   current_suite := name;
@@ -543,12 +524,4 @@ let () =
 
   (* ── Summary ─────────────────────────────────────────── *)
   Printf.printf "\n════════════════════════════════════════════\n";
-  Printf.printf "  Results: %d/%d passed" !tests_passed !tests_run;
-  if !tests_failed > 0 then
-    Printf.printf " (%d FAILED)" !tests_failed;
-  Printf.printf "\n════════════════════════════════════════════\n";
-
-  if !tests_failed > 0 then
-    exit 1
-  else
-    Printf.printf "✅ All queue tests passed!\n"
+  test_summary ()

--- a/test_rope.ml
+++ b/test_rope.ml
@@ -1,35 +1,11 @@
 (* test_rope.ml — Tests for Rope module *)
 (* Run: ocaml test_rope.ml *)
 
+#use "test_framework.ml";;
 #use "rope.ml";;
 
 open Rope
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
-
-let assert_true ~msg cond =
-  incr tests_run;
-  if cond then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL: %s\n" msg
-  end
-
-let assert_equal ~msg expected actual =
-  incr tests_run;
-  if expected = actual then incr tests_passed
-  else begin
-    incr tests_failed;
-    Printf.printf "  FAIL: %s (expected %s, got %s)\n" msg expected actual
-  end
-
-let assert_raises ~msg f =
-  incr tests_run;
-  try ignore (f ()); incr tests_failed;
-      Printf.printf "  FAIL: %s: expected exception\n" msg
-  with _ -> incr tests_passed
 
 (* ============================================================ *)
 (* Construction                                                  *)
@@ -460,6 +436,4 @@ let () =
 (* Summary                                                       *)
 (* ============================================================ *)
 let () =
-  Printf.printf "\nRope tests: %d passed, %d failed, %d total\n"
-    !tests_passed !tests_failed !tests_run;
-  if !tests_failed > 0 then exit 1
+  test_summary ()

--- a/test_signal_processing.ml
+++ b/test_signal_processing.ml
@@ -1,15 +1,7 @@
 (* test_signal_processing.ml — Tests for signal processing module *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
 
-let assert_true ~msg b =
-  incr tests_run;
-  if b then (
-    incr tests_passed;
-    Printf.printf "  ✓ %s\n" msg
-  ) else
-    Printf.printf "  ✗ %s\n" msg
+#use "test_framework.ml";;
 
 let assert_float ~msg ~eps expected actual =
   incr tests_run;
@@ -26,13 +18,6 @@ let assert_int ~msg expected actual =
     Printf.printf "  ✓ %s\n" msg
   ) else
     Printf.printf "  ✗ %s (expected %d, got %d)\n" msg expected actual
-
-let assert_raises ~msg f =
-  incr tests_run;
-  try f (); Printf.printf "  ✗ %s (no exception raised)\n" msg
-  with _ -> (
-    incr tests_passed;
-    Printf.printf "  ✓ %s\n" msg)
 
 open Signal_processing
 
@@ -441,5 +426,4 @@ let () =
   test_time_domain ();
   test_filtering ();
   test_integration ();
-  Printf.printf "\n%d/%d tests passed\n" !tests_passed !tests_run;
-  if !tests_passed < !tests_run then exit 1
+  test_summary ()

--- a/test_suffix_array.ml
+++ b/test_suffix_array.ml
@@ -1,9 +1,8 @@
 (* test_suffix_array.ml — Tests for Suffix Array module *)
 (* Compile: ocamlopt suffix_array.ml test_suffix_array.ml -o test_sa *)
 
-let tests_run = ref 0
-let tests_passed = ref 0
-let tests_failed = ref 0
+#use "test_framework.ml";;
+
 let current_suite = ref ""
 
 let assert_equal_int ~msg expected actual =
@@ -19,12 +18,6 @@ let assert_equal_str ~msg expected actual =
   else begin incr tests_failed;
     Printf.printf "  FAIL [%s] %s: expected \"%s\", got \"%s\"\n"
       !current_suite msg expected actual end
-
-let assert_true ~msg condition =
-  incr tests_run;
-  if condition then incr tests_passed
-  else begin incr tests_failed;
-    Printf.printf "  FAIL [%s] %s\n" !current_suite msg end
 
 let assert_list_equal ~msg expected actual =
   incr tests_run;
@@ -210,8 +203,4 @@ let () =
   Printf.printf "\n=== Suffix Array Test Suite ===\n\n";
   test_build (); test_lcp (); test_search (); test_count ();
   test_lrs (); test_distinct (); test_kth (); test_bwt (); test_edge ();
-  Printf.printf "\n=== Results ===\n";
-  Printf.printf "Total: %d | Passed: %d | Failed: %d\n"
-    !tests_run !tests_passed !tests_failed;
-  if !tests_failed > 0 then (Printf.printf "STATUS: SOME TESTS FAILED\n"; exit 1)
-  else (Printf.printf "STATUS: ALL TESTS PASSED\n"; exit 0)
+  test_summary ()


### PR DESCRIPTION
Extracts a shared test assertion library (test_framework.ml) with assert_true, assert_equal, assert_raises, assert_float_eq, suite, and test_summary. Refactors 14 test files to use it instead of duplicating their own assertion functions and counters. Removes ~350 lines of boilerplate.